### PR TITLE
Replace all visible instances of Canafis with Canifis, improve chat and notification messages, improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
-This plugin allows the player to track the mark of grace cooldown on the canafis agility course.
+## AFK Marks Canifis
+This plugin allows the player to track the marks of grace cooldown on the Canifis Rooftop Agility Course. It makes use of the marks of grace spawning mechanic as mentioned in the OSRS Wiki:
 
-This is how you can use it:
-1. Run the canafis course until u find a mark of grace (this is 66% per run) and the overlay will appear
-2. Wait on the last roof of the course (the overlay will say wait)
-3. AFK until the timer runs out and you get a notify
-4. Run the course (the overlay will say run) 
-5. Repeat
+    Each course has a chance to spawn a mark of grace upon completion given that enough time has passed since the last mark of grace was spawned. For most courses this is three minutes. [...]
 
-Note, this uses the local pc's time, if your time is incorrect for some reason on a seconds level, this could make the plugin less reliable.
+    This timer works on the scale of minutes, so if a mark of grace spawned at 00:00 game time, you would have another chance starting from the first tick of game time 00:03, regardless of what tick the mark spawned at during 00:00. This timer persists even after logging out or changing worlds.
+
+    Upon completing a lap after the timer has expired, the chance to have a mark of grace spawn is [...] 2/3 for the Canifis and Ardougne Rooftop Course, [...].
+
+This allows us to maximize the marks of grace spawning while minimizing our effort to get them by waiting on the last rooftop, just before jumping down to get your big Agility XP drop.
+ 
+## How to use
+1. Run the Canifis Rooftop Agility Course until you find a mark of grace and the overlay will appear.
+2. When the overlay says wait, wait on the last rooftop of the course until the timer runs out.
+3. When the timer runs out, you will get a notification. You can now jump down from the course, this will generate a new mark of grace with a 2/3 chance.
+4. Run the course (the overlay will say run).
+5. Repeat!
+
+**Note:** this uses the local PC's time. If your time is incorrect for some reason on a seconds level, this could make the plugin less reliable.

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
-displayName=Afk Marks Canafis
+displayName=AFK Marks Canifis
 author=powerus117
 support=
-description=Allows you to afk on the last roof of canafis for marks
-tags=mark,marks,grace,canafis,course,rooftop,afk
+description=Allows you to AFK on the last roof of the Canifis Rooftop Agility Course for marks of grace.
+tags=mark,marks,grace,canafis,canifis,course,rooftop,afk
 plugins=com.afkmarkscanafis.AfkMarksCanafisPlugin

--- a/src/main/java/com/afkmarkscanafis/AfkMarksCanafisPlugin.java
+++ b/src/main/java/com/afkmarkscanafis/AfkMarksCanafisPlugin.java
@@ -25,7 +25,9 @@ import static net.runelite.api.Skill.AGILITY;
 
 @Slf4j
 @PluginDescriptor(
-	name = "Afk Marks Canafis"
+	name = "AFK Marks Canifis",
+	description = "Allows you to AFK on the last roof of the Canifis Rooftop Agility Course for marks of grace.",
+	tags = {"afk", "mark", "grace", "canifis"}
 )
 public class AfkMarksCanafisPlugin extends Plugin
 {
@@ -129,8 +131,8 @@ public class AfkMarksCanafisPlugin extends Plugin
 			if (zonedNow.isAfter(markCooldownCompleteTime))
 			{
 				shouldRun = true;
-				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Mark cooldown finished, run", null);
-				notifier.notify("Mark of grace cooldown finished");
+				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Marks of grace cooldown has finished, run until you find your next mark.", null);
+				notifier.notify("Marks of grace cooldown has finished.");
 			}
 		}
 	}


### PR DESCRIPTION
Hi powerus117,

Thank you for writing this plugin (I was actually using it while writing this pull request). It works really well and helps out a lot.

However, I noticed when searching for it that it was hard to find. Later I found out that this was due to the fact that the name of the town was written wrong consistently throughout the plugin. That's why I wrote this pull request containing the following changes:

- Replaced all front-end occurrences of "Canafis" with "Canifis". Occurrences of "Canafis" that are essential to the code like function names remain untouched.
- Plugin description and tags are improved and added a RuneLite plugins hover description.
- The README is improved to include information about the marks of grace spawning mechanics.
- Notification messages are improved for consistency and proper naming.

I hope this helps more people find your plugin, cheers!