### PR TITLE
Update to use RuneLite Notification class

### DIFF
--- a/src/main/java/com/marksofgracecooldown/MarksOfGraceCDConfig.java
+++ b/src/main/java/com/marksofgracecooldown/MarksOfGraceCDConfig.java
@@ -4,19 +4,20 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.Units;
+import net.runelite.client.config.Notification;
 
 @ConfigGroup("AfkMarksCanafis")  // Old name from when it was canifis only
 public interface MarksOfGraceCDConfig extends Config
 {
 	@ConfigItem(
-		keyName = "sendNotification",
-		name = "Send notification",
-		description = "Should a notification be send when the cooldown has expired",
+		keyName = "cooldownNotifier",
+		name = "Cooldown notifier",
+		description = "Notify when the cooldown has expired.",
 		position = 0
 	)
-	default boolean sendNotification()
+	default Notification notifyMarksOfGraceCD()
 	{
-		return true;
+		return Notification.ON;
 	}
 
     @ConfigItem(

--- a/src/main/java/com/marksofgracecooldown/MarksOfGraceCDPlugin.java
+++ b/src/main/java/com/marksofgracecooldown/MarksOfGraceCDPlugin.java
@@ -109,10 +109,7 @@ public class MarksOfGraceCDPlugin extends Plugin
 				isOnCooldown = false;
 				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "Marks of grace cooldown has finished, run until you find your next mark.", null);
 
-				if (config.sendNotification())
-				{
-					notifier.notify("Marks of grace cooldown has finished.");
-				}
+                notifier.notify(config.notifyMarksOfGraceCD(), "Marks of grace cooldown has finished.");
 			}
 		}
 	}


### PR DESCRIPTION
I noticed that I could [customize the notifications](https://runelite.net/blog/show/2024-04-17-1.10.27-Release/) on other plugins while this one was a checkbox. Looked into it and saw that newer plugins pass a Notification class to the notifier.

I followed the convention that the Agility built-in plugin used here: 
https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/plugins/agility/AgilityPlugin.java

Screenshots:

New:
<img width="236" height="69" alt="image" src="https://github.com/user-attachments/assets/d93f0e5f-6d2e-4a39-a0c2-f757d083fd45" />

<img width="240" height="353" alt="image" src="https://github.com/user-attachments/assets/f936f907-1f01-4366-a8ff-87559e07f92e" />

Thanks for your hard work! Currently grinding Graceful, haha